### PR TITLE
Changes to topnav, added documentation links

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -1,34 +1,61 @@
 ## Topnav single links
 ## if you want to list an external url, use external_url instead of url. the theme will apply a different link base.
 
-#Topnav dropdowns
-topnav_dropdowns:
-- title: Topnav dropdowns
-  folders:
+topnav:
+- items:
   - title: About
-    output: web
     url: /about.html
-
+    
   - title: Capabilities
     url: /capabilities.html
-    output: web
 
+  - title: Packages
+    url: /packages-by-area.html
+    
   - title: Getting Started
-    output: web
     url: /getting_started.html
 
   - title: Documentation
     url: /documentation.html
-    output: web
 
   - title: Community
     url: /community.html
-    output: web
 
   - title: Support
-    output: web
     url: /support.html
 
   - title: Download
     url: /download.html
-    output: web
+
+    
+#Topnav dropdowns
+# topnav_dropdowns:
+# - title: Topnav dropdowns
+#   folders:
+  # - title: About
+  #   output: web
+  #   url: /about.html
+
+  # - title: Capabilities
+  #   url: /capabilities.html
+  #   output: web
+
+  # - title: Getting Started
+  #   output: web
+  #   url: /getting_started.html
+
+  # - title: Documentation
+  #   url: /documentation.html
+  #   output: web
+
+  # - title: Community
+  #   url: /community.html
+  #   output: web
+
+  # - title: Support
+  #   output: web
+  #   url: /support.html
+
+  # - title: Download
+  #   url: /download.html
+  #   output: web

--- a/index.md
+++ b/index.md
@@ -17,6 +17,14 @@ Join us in harnessing the power of Trilinos to drive innovation and discovery in
 Explore Trilinos resources:
 
 <div class="quick-links-grid">
+    <div class="quick-link-box">
+    <h3><a href="getting_started.html">Getting started</a></h3>
+    <p>First steps with Trilinos: installation and usage <a href="getting_started.html">More...</a></p>
+  </div>
+  <div class="quick-link-box">
+    <h3><a href="events.html">Events</a></h3>
+    <p>Stay updated on workshops, webinars, and community events. <a href="events.html">More...</a></p>
+  </div>
   <div class="quick-link-box">
     <h3><a href="https://github.com/trilinos/Trilinos">Trilinos GitHub Repository</a></h3>
     <p>Access the source code and contribute to Trilinos development. <a href="https://github.com/trilinos/Trilinos">More...</a></p>
@@ -24,10 +32,6 @@ Explore Trilinos resources:
   <div class="quick-link-box">
     <h3><a href="packages-by-area.html">Doxygen Documentation</a></h3>
     <p>Explore the API documentation for Trilinos packages. <a href="packages-by-area.html">More...</a></p>
-  </div>
-  <div class="quick-link-box">
-    <h3><a href="events.html">Events</a></h3>
-    <p>Stay updated on workshops, webinars, and community events. <a href="events.html">More...</a></p>
   </div>
 </div>
 

--- a/pages/capabilities.md
+++ b/pages/capabilities.md
@@ -14,140 +14,140 @@ Trilinos is a comprehensive software framework for scientific computing, providi
 ## Performance Portability and Core Utilities
 
 - **Performance Portability**  
-  Tools for enabling efficient computation across diverse hardware architectures, including CPUs, GPUs, and emerging HPC systems. Capabilities include abstractions for parallel execution, memory spaces, and hierarchical parallelism.  Support for expressing parallel computations at multiple levels, including thread, team, and vector levels, ensuring efficient utilization of hardware resources.  Abstractions for memory management, including multidimensional arrays with customizable memory layouts and traits for optimized data access patterns.  _Provided by: <a href="https://kokkos.org/" title="Kokkos">Kokkos</a>_
+  Tools for enabling efficient computation across diverse hardware architectures, including CPUs, GPUs, and emerging HPC systems. Capabilities include abstractions for parallel execution, memory spaces, and hierarchical parallelism.  Support for expressing parallel computations at multiple levels, including thread, team, and vector levels, ensuring efficient utilization of hardware resources.  Abstractions for memory management, including multidimensional arrays with customizable memory layouts and traits for optimized data access patterns.  _Provided by package: [Kokkos](https://kokkos.org/)_
 
 - **Mathematical Kernels for Node-Local Computations**  
-  Performance-portable implementations of mathematical kernels for dense and sparse linear algebra, graph algorithms, and batched computations. Capabilities include optimized sparse matrix operations, efficient BLAS routines, graph-based computations, and integration with vendor-optimized libraries. Thread-safe and asynchronous implementations ensure efficient concurrent execution and scalability.  _Provided by: <a href="https://kokkos.org/" title="Kokkos Kernels">Kokkos Kernels</a>_
+  Performance-portable implementations of mathematical kernels for dense and sparse linear algebra, graph algorithms, and batched computations. Capabilities include optimized sparse matrix operations, efficient BLAS routines, graph-based computations, and integration with vendor-optimized libraries. Thread-safe and asynchronous implementations ensure efficient concurrent execution and scalability.  _Provided by package: [Kokkos Kernels](https://kokkos.org/)_
 
 - **Distributed-Memory Linear Algebra**  
-  Scalable infrastructure for distributed-memory computations, providing linear algebra objects such as sparse matrices, dense vectors, and graphs. Supports efficient parallel operations using MPI-based communication, including sparse matrix-vector multiplication, matrix-matrix multiplication, and graph-based operations. Features include data redistribution, halo exchange, and flexible templated objects for compatibility with diverse applications and architectures. Essential for large-scale simulations on leadership-class systems.  _Provided by: <a href="tpetra.html" title="Tpetra">Tpetra</a>_
+  Scalable infrastructure for distributed-memory computations, providing linear algebra objects such as sparse matrices, dense vectors, and graphs. Supports efficient parallel operations using MPI-based communication, including sparse matrix-vector multiplication, matrix-matrix multiplication, and graph-based operations. Features include data redistribution, halo exchange, and flexible templated objects for compatibility with diverse applications and architectures. Essential for large-scale simulations on leadership-class systems.  _Provided by package: [Tpetra](tpetra)_
 
 - **Utility and Helper Tools**  
-  Collection of tools for memory management, parameter lists, templated wrappers for BLAS/LAPACK, and XML parsing. These utilities simplify programming tasks and ensure consistent coding practices.  _Provided by: <a href="teuchos.html" title="Teuchos">Teuchos</a>_
+  Collection of tools for memory management, parameter lists, templated wrappers for BLAS/LAPACK, and XML parsing. These utilities simplify programming tasks and ensure consistent coding practices.  _Provided by package: [Teuchos](teuchos)_
 
 ---
 
 ## Linear Solvers
 
 - **Iterative Linear Solvers**  
-  Comprehensive suite of iterative solvers for linear systems, including Krylov methods such as CG, GMRES, MINRES, and BiCGStab. These solvers support block and pseudo-block methods for solving systems with multiple right-hand sides, as well as advanced techniques like flexible GMRES and pipelined CG.  _Provided by: <a href="belos.html" title="Belos">Belos</a>_
+  Comprehensive suite of iterative solvers for linear systems, including Krylov methods such as CG, GMRES, MINRES, and BiCGStab. These solvers support block and pseudo-block methods for solving systems with multiple right-hand sides, as well as advanced techniques like flexible GMRES and pipelined CG.  _Provided by package: [Belos](belos)_
 
 - **Direct Linear Solvers**  
-  Direct solvers for sparse linear systems, including interfaces to third-party solvers and node-local solvers optimized for shared-memory architectures. These solvers are essential for problems requiring robust and accurate solutions, such as circuit simulations and mechanics applications.  _Provided by: <a href="amesos2.html" title="Amesos2">Amesos2</a>, <a href="shylu.html" title="ShyLU">ShyLU</a>, <a href="adelus.html" title="Adelus">Adelus</a>_
+  Direct solvers for sparse linear systems, including interfaces to third-party solvers and node-local solvers optimized for shared-memory architectures. These solvers are essential for problems requiring robust and accurate solutions, such as circuit simulations and mechanics applications.  _Provided by package: [Amesos2](amesos2), [ShyLU](shylu), [Adelus](adelus)_
 
 - **Large-Scale Eigenvalue Algorithms**  
-  Framework for solving large-scale eigenvalue problems, including methods such as block Davidson, Krylov-Schur, locally optimal block preconditioned conjugate gradient (LOBPCG), and trace minimization. These algorithms are designed to handle large, sparse matrices arising in scientific and engineering applications, providing flexibility and scalability for diverse use cases.  _Provided by: <a href="anasazi.html" title="Anasazi">Anasazi</a>_
+  Framework for solving large-scale eigenvalue problems, including methods such as block Davidson, Krylov-Schur, locally optimal block preconditioned conjugate gradient (LOBPCG), and trace minimization. These algorithms are designed to handle large, sparse matrices arising in scientific and engineering applications, providing flexibility and scalability for diverse use cases.  _Provided by package: [Anasazi](anasazi)_
 
 ---
 
 ## Preconditioners
 
 - **One-Level Domain Decomposition**  
-  Overlapping additive Schwarz methods for preconditioning, with options for local subdomain solves such as incomplete LU factorizations and direct solvers. These methods accelerate iterative solvers and include classic iterative techniques like Jacobi, Gauss-Seidel, and Chebyshev iterations, optimized for shared-memory architectures.  _Provided by: <a href="ifpack2.html" title="Ifpack2">Ifpack2</a>_
+  Overlapping additive Schwarz methods for preconditioning, with options for local subdomain solves such as incomplete LU factorizations and direct solvers. These methods accelerate iterative solvers and include classic iterative techniques like Jacobi, Gauss-Seidel, and Chebyshev iterations, optimized for shared-memory architectures.  _Provided by package: [Ifpack2](ifpack2)_
 
 - **Multilevel Domain Decomposition**  
-  Multilevel Schwarz preconditioners that emphasize scalability and robustness across challenging problems. These preconditioners support extension-based coarse spaces and are designed for algebraic construction, relying solely on the sparsity pattern of the system matrix. They have demonstrated scalability to hundreds of thousands of cores on supercomputers.  _Provided by: <a href="https://shylu-frosch.github.io/" title="FROSch">FROSch</a>_
+  Multilevel Schwarz preconditioners that emphasize scalability and robustness across challenging problems. These preconditioners support extension-based coarse spaces and are designed for algebraic construction, relying solely on the sparsity pattern of the system matrix. They have demonstrated scalability to hundreds of thousands of cores on supercomputers.  _Provided by package: [FROSch](https://shylu-frosch.github.io/)_
 
 - **Multigrid Methods**  
-  Scalable multigrid solvers for a wide range of PDEs, including Poisson-like operators, elasticity, convection-diffusion, and Maxwell’s equations. These solvers include aggregation-based algebraic multigrid methods, semi-coarsening for structured grids, and specialized solvers for multiphysics problems.  _Provided by: <a href="muelu.html" title="MueLu">MueLu</a>_
+  Scalable multigrid solvers for a wide range of PDEs, including Poisson-like operators, elasticity, convection-diffusion, and Maxwell’s equations. These solvers include aggregation-based algebraic multigrid methods, semi-coarsening for structured grids, and specialized solvers for multiphysics problems.  _Provided by package: [MueLu](muelu)_
 
 - **Physics-Based Block Preconditioners**  
-  Block preconditioning strategies for multiphysics problems, leveraging the block structure of matrices to create efficient solvers. Strategies include block LU factorizations, SIMPLEC, LSC, and PCD preconditioners, with flexibility for defining custom inverse approximations for Schur complements.  _Provided by: <a href="teko.html" title="Teko">Teko</a>_
+  Block preconditioning strategies for multiphysics problems, leveraging the block structure of matrices to create efficient solvers. Strategies include block LU factorizations, SIMPLEC, LSC, and PCD preconditioners, with flexibility for defining custom inverse approximations for Schur complements.  _Provided by package: [Teko](teko)_
 
 ---
 
 ## Discretization Utilities
 
 - **Finite Element Local Assembly**  
-  Tools for local assembly of finite element matrices and vectors, supporting high-order compatible discretizations for function spaces such as H(grad), H(curl), H(div), and L<sup>2</sup>. Capabilities include geometric operations, basis functions, orientation tools, and projection methods for efficient finite element computations.  _Provided by: <a href="intrepid2.html" title="Intrepid2">Intrepid2</a>_
+  Tools for local assembly of finite element matrices and vectors, supporting high-order compatible discretizations for function spaces such as H(grad), H(curl), H(div), and L<sup>2</sup>. Capabilities include geometric operations, basis functions, orientation tools, and projection methods for efficient finite element computations.  _Provided by package: [Intrepid2](intrepid2)_
 
 - **Finite Element Assembly for Multiphysics Systems**  
-  Tools for efficient finite element assembly, supporting mixed bases, multiphysics systems, and high-order discretizations. Capabilities include dependency management, distributed assembly, and support for block or fully coupled systems. Integrated with automatic differentiation for Jacobians and sensitivities, enabling scalable simulations and optimization.  _Provided by: <a href="panzer.html" title="Panzer">Panzer</a>_
+  Tools for efficient finite element assembly, supporting mixed bases, multiphysics systems, and high-order discretizations. Capabilities include dependency management, distributed assembly, and support for block or fully coupled systems. Integrated with automatic differentiation for Jacobians and sensitivities, enabling scalable simulations and optimization.  _Provided by package: [Panzer](panzer)_
 
 - **Field Evaluation and Dependency Management**  
-  Graph-based design for managing dependencies in PDE assembly, enabling rapid prototyping and integration of automatic differentiation tools. These capabilities support efficient evaluation of fields and derivatives, automating the computation of Jacobians, sensitivities, and other quantities required for nonlinear solvers and optimization.  _Provided by: <a href="phalanx.html" title="Phalanx">Phalanx</a>_
+  Graph-based design for managing dependencies in PDE assembly, enabling rapid prototyping and integration of automatic differentiation tools. These capabilities support efficient evaluation of fields and derivatives, automating the computation of Jacobians, sensitivities, and other quantities required for nonlinear solvers and optimization.  _Provided by package: [Phalanx](phalanx)_
 
 - **Meshless Approximation of Linear Operators**  
-  Tools for meshless approximation of linear operators using generalized moving least squares (GMLS). These capabilities support applications such as data transfer and meshless discretization of PDEs, leveraging hierarchical parallelism for performance portability.  _Provided by: <a href="compadre.html" title="Compadre">Compadre</a>_
+  Tools for meshless approximation of linear operators using generalized moving least squares (GMLS). These capabilities support applications such as data transfer and meshless discretization of PDEs, leveraging hierarchical parallelism for performance portability.  _Provided by package: [Compadre](compadre)_
 
 ---
 
 ## Nonlinear, Transient, and Optimization Solvers
 
 - **Nonlinear Solvers**  
-  Algorithms for solving nonlinear equations, including Newton-based methods, line search, trust region, and homotopy techniques. These solvers support Jacobian-free Newton-Krylov variants and provide robust options for handling large-scale nonlinear systems.  _Provided by: <a href="nox_and_loca.html" title="NOX">NOX</a>_
+  Algorithms for solving nonlinear equations, including Newton-based methods, line search, trust region, and homotopy techniques. These solvers support Jacobian-free Newton-Krylov variants and provide robust options for handling large-scale nonlinear systems.  _Provided by package: [NOX](nox_and_loca)_
 
 - **Continuation and Stability Analysis**  
-  Techniques for tracking solution families and investigating stability, including pseudo-arclength continuation, bifurcation tracking, and eigenvalue analysis. These capabilities are widely used in applications such as fluid dynamics and chemical reactor design.  _Provided by: <a href="nox_and_loca.html" title="LOCA">LOCA</a>_
+  Techniques for tracking solution families and investigating stability, including pseudo-arclength continuation, bifurcation tracking, and eigenvalue analysis. These capabilities are widely used in applications such as fluid dynamics and chemical reactor design.  _Provided by package: [LOCA](nox_and_loca)_
 
 - **Transient Solvers**  
-  Framework for time integration, supporting explicit and implicit methods for first- and second-order ODEs. Capabilities include error control, sensitivity analysis, and transient optimization, making them suitable for simulations ranging from small systems to exascale computing.  _Provided by: <a href="tempus.html" title="Tempus">Tempus</a>_
+  Framework for time integration, supporting explicit and implicit methods for first- and second-order ODEs. Capabilities include error control, sensitivity analysis, and transient optimization, making them suitable for simulations ranging from small systems to exascale computing.  _Provided by package: [Tempus](tempus)_
 
 - **Optimization Solvers**  
-  State-of-the-art algorithms for constrained and unconstrained optimization, including trust-region methods, stochastic optimization, and nonsmooth optimization. These solvers support matrix-free computations and integrate seamlessly with PDE models for efficient optimization.  _Provided by: <a href="rol.html" title="ROL">ROL</a>_
+  State-of-the-art algorithms for constrained and unconstrained optimization, including trust-region methods, stochastic optimization, and nonsmooth optimization. These solvers support matrix-free computations and integrate seamlessly with PDE models for efficient optimization.  _Provided by package: [ROL](rol)_
 
 ---
 
 ## Automatic Differentiation
 
 - **Forward and Reverse Mode AD**  
-  Tools for automatic differentiation using operator overloading, enabling efficient computation of derivatives for complex models. These capabilities integrate with performance-portable architectures, making them suitable for GPU-based systems and large-scale applications.  _Provided by: <a href="sacado.html" title="Sacado">Sacado</a>_
+  Tools for automatic differentiation using operator overloading, enabling efficient computation of derivatives for complex models. These capabilities integrate with performance-portable architectures, making them suitable for GPU-based systems and large-scale applications.  _Provided by package: [Sacado](sacado)_
 
 ---
 
 ## Uncertainty Quantification
 
 - **Uncertainty Quantification and Stochastic Methods**  
-  Tools for intrusive uncertainty quantification methods, including stochastic Galerkin projections and embedded ensemble propagation. Capabilities include efficient computation of polynomial chaos expansions, block-structured linear systems, and scalable ensemble-based simulations. Optimized for performance on modern architectures, enabling uncertainty propagation in large-scale multiphysics systems.  _Provided by: <a href="stokhos.html" title="Stokhos">Stokhos</a>_
+  Tools for intrusive uncertainty quantification methods, including stochastic Galerkin projections and embedded ensemble propagation. Capabilities include efficient computation of polynomial chaos expansions, block-structured linear systems, and scalable ensemble-based simulations. Optimized for performance on modern architectures, enabling uncertainty propagation in large-scale multiphysics systems.  _Provided by package: [Stokhos](stokhos)_
 
 ---
 
 ## Partitioning and Load Balancing
 
 - **Partitioning and Load Balancing**  
-  Tools for efficiently partitioning and distributing data objects such as sparse matrices across processors, ensuring balanced computational loads and minimizing communication overhead. These capabilities include support for hybrid parallelism and advanced algorithms like geometric partitioning, spectral graph partitioning, graph coloring, and MPI task placement.  _Provided by: <a href="zoltan.html" title="Zoltan">Zoltan</a>, <a href="zoltan2.html" title="Zoltan">Zoltan2</a>_
+  Tools for efficiently partitioning and distributing data objects such as sparse matrices across processors, ensuring balanced computational loads and minimizing communication overhead. These capabilities include support for hybrid parallelism and advanced algorithms like geometric partitioning, spectral graph partitioning, graph coloring, and MPI task placement.  _Provided by package: [Zoltan](zoltan), [Zoltan](zoltan2)_
 
 ---
 
 ## Mesh and Geometry Tools
 
 - **Mesh Generation**  
-  Tools for generating meshes for computational simulations, including structured, unstructured, and hybrid meshes. These capabilities support the creation of meshes for complex geometries and multiphysics applications.  _Provided by: <a href="pamgen.html" title="PAMGEN">PAMGEN</a>_
+  Tools for generating meshes for computational simulations, including structured, unstructured, and hybrid meshes. These capabilities support the creation of meshes for complex geometries and multiphysics applications.  _Provided by package: [PAMGEN](pamgen)_
 
 - **Mesh Manipulation**  
-  Utilities for modifying meshes, including operations such as mesh refinement, coarsening, and partitioning. These tools allow users to adapt meshes to specific simulation requirements or improve computational efficiency.  _Provided by: <a href="https://github.com/sandialabs/seacas" title="SEACAS">SEACAS</a>, <a href="stk.html" title="STK">STK</a>, <a href="percept.html" title="Percept">Percept</a>_
+  Utilities for modifying meshes, including operations such as mesh refinement, coarsening, and partitioning. These tools allow users to adapt meshes to specific simulation requirements or improve computational efficiency.  _Provided by package: [SEACAS](https://github.com/sandialabs/seacas), [STK](stk), [Percept](percept)_
 
 - **Mesh I/O**  
-  Support for reading and writing mesh data in various formats, including Exodus, NetCDF, and other widely used formats in scientific computing. These capabilities enable interoperability with external mesh generation and visualization tools. Integration with visualization tools for inspecting and analyzing mesh structures and simulation results. These capabilities include support for exporting data to visualization software such as ParaView and VisIt. _Provided by: <a href="https://github.com/sandialabs/seacas" title="SEACAS">SEACAS</a>, <a href="stk.html" title="STK">STK</a>_
+  Support for reading and writing mesh data in various formats, including Exodus, NetCDF, and other widely used formats in scientific computing. These capabilities enable interoperability with external mesh generation and visualization tools. Integration with visualization tools for inspecting and analyzing mesh structures and simulation results. These capabilities include support for exporting data to visualization software such as ParaView and VisIt. _Provided by package: [SEACAS](https://github.com/sandialabs/seacas), [STK](stk)_
 
 - **Cell Topology**  
-  Tools for defining and querying cell topology, including support for triangles, quadrilaterals, tetrahedrons, hexahedrons, wedges, and pyramids. These capabilities are essential for finite element and finite volume discretizations.  _Provided by: <a href="shards.html" title="Shards">Shards</a>_
+  Tools for defining and querying cell topology, including support for triangles, quadrilaterals, tetrahedrons, hexahedrons, wedges, and pyramids. These capabilities are essential for finite element and finite volume discretizations.  _Provided by package: [Shards](shards)_
 
 - **Level-Set Methods**  
-  Capabilities for handling level-set representations of geometries, enabling simulations involving moving boundaries, interfaces, and topological changes. These methods are particularly useful for fluid-structure interaction and multiphase flow problems.  _Provided by: <a href="krino.html" title="Krino">Krino</a>_
+  Capabilities for handling level-set representations of geometries, enabling simulations involving moving boundaries, interfaces, and topological changes. These methods are particularly useful for fluid-structure interaction and multiphase flow problems.  _Provided by package: [Krino](krino)_
 
 - **Mesh Refinement and Adaptivity**  
-  Tools for refining and adapting meshes based on simulation results, including error indicators and solution gradients. These capabilities ensure accurate and efficient simulations by dynamically adjusting the mesh resolution.  _Provided by: <a href="stk.html" title="STK">STK</a>_
+  Tools for refining and adapting meshes based on simulation results, including error indicators and solution gradients. These capabilities ensure accurate and efficient simulations by dynamically adjusting the mesh resolution.  _Provided by package: [STK](stk)_
 
 - **Mesh Quality Assessment**  
-  Utilities for assessing and improving mesh quality, including metrics for element shape, size, and aspect ratio. These tools help ensure that meshes are suitable for high-fidelity simulations.  _Provided by: <a href="https://github.com/sandialabs/seacas" title="SEACAS">SEACAS</a>, <a href="percept.html" title="Percept">Percept</a>_
+  Utilities for assessing and improving mesh quality, including metrics for element shape, size, and aspect ratio. These tools help ensure that meshes are suitable for high-fidelity simulations.  _Provided by package: [SEACAS](https://github.com/sandialabs/seacas), [Percept](percept)_
 
 - **Mesh-Based Data Transfer**  
   Support for transferring data between meshes, including interpolation and projection methods for scalar, vector, and tensor fields. These capabilities are critical for multiphysics simulations and coupling between different models.  
-  _Provided by: <a href="https://github.com/sandialabs/seacas" title="SEACAS">SEACAS</a>, <a href="stk.html" title="STK">STK</a>_
+  _Provided by package: [SEACAS](https://github.com/sandialabs/seacas), [STK](stk)_
 
 ---
 
 ## Interfaces and Adapters
 
 - **Unified Solver Interface**  
-  Cohesive interface to linear solvers and preconditioners, enabling runtime configuration through parameter lists. This interface simplifies solver management for complex applications and supports integration with multiple linear algebra backends.  _Provided by: <a href="stratimikos.html" title="Stratimikos">Stratimikos</a>_
+  Cohesive interface to linear solvers and preconditioners, enabling runtime configuration through parameter lists. This interface simplifies solver management for complex applications and supports integration with multiple linear algebra backends.  _Provided by package: [Stratimikos](stratimikos)_
 
 - **Python Wrappers**  
-  Python interfaces for selected capabilities, enabling rapid prototyping and algorithm development. These wrappers provide access to linear algebra, solvers, and preconditioners for efficient experimentation and integration.  _Provided by: <a href="pytrilinos2.html" title="PyTrilinos2">PyTrilinos2</a>_
+  Python interfaces for selected capabilities, enabling rapid prototyping and algorithm development. These wrappers provide access to linear algebra, solvers, and preconditioners for efficient experimentation and integration.  _Provided by package: [PyTrilinos2](pytrilinos2)_
 
 - **Abstract Numerical Algorithms**  
-  Interfaces for implementing high-level abstract numerical algorithms, enabling separation of algorithm development from linear algebra implementation. These abstractions support efficient reuse across multiple applications.  _Provided by: <a href="thyra.html" title="Thyra">Thyra</a>_
+  Interfaces for implementing high-level abstract numerical algorithms, enabling separation of algorithm development from linear algebra implementation. These abstractions support efficient reuse across multiple applications.  _Provided by package: [Thyra](thyra)_
 
 ---
 
@@ -155,6 +155,6 @@ Trilinos continues to evolve, providing cutting-edge tools for scientific comput
 
 ## Trilinos Packages
 
-<a href="packages-by-area.html" title="Trilinos Packages by Area">Trilinos Packages by Area.</a>
+[Trilinos Packages by Area](packages-by-area)
 
 

--- a/pages/community/events.md
+++ b/pages/community/events.md
@@ -6,8 +6,8 @@ folder: community
 
 ## Upcoming Meetings
 
-*   [European workshop on high-performance software 2026](https://github.com/EuroTUG/eurotug_2026) -- February 25 - 27, 2026, TU Braunschweig
-*   [US Trilinos User & Developer Group Meeting 2026](trilinos_user-developer_group_meeting_2026.html) -- March 18-19, 2026, Chicago, IL, USA
+*   [HPSF Community Summit 2026](https://events.academiccloud.de/event/143/) -- February 25 - 27, 2026, TU Braunschweig
+*   [Trilinos User & Developer Group Meeting @ HPSF Conference 2026](trilinos_user-developer_group_meeting_2026.html) -- March 18-19, 2026, Chicago, IL, USA
 
 ## Past Meetings
 

--- a/pages/documentation.md
+++ b/pages/documentation.md
@@ -14,6 +14,7 @@ Find out more about Trilinos: how to use it, install it, configure it, and even 
 
 - [Trilinos: Enabling Scientific Computing Across Diverse Hardware Architectures at Scale](https://arxiv.org/abs/2503.08126)
     - An overview of the Trilinos framework, highlighting its design principles, modular architecture, and scalability for scientific computing on modern hardware platforms.
+    - Submitted in 2025.
 - [An Overview of the Trilinos Project](pdfs/TrilinosACMTOMS2004.pdf) 
     - ACM Transactions on Mathematical Software, Vol. 31, Issue 3, September 2005, Pages 397-423.
 - [An Overview of Trilinos](pdfs/TrilinosOverview.pdf)

--- a/pages/packages-by-area.md
+++ b/pages/packages-by-area.md
@@ -1,7 +1,7 @@
 ---
 title: Packages by Area 
 permalink: packages-by-area.html
-keywords: Area Leads, Core Area, Solvers Area, Discretization and Analysis Area, Linear Systems, Performance Portability, Finite Element Analysis, Preconditioners, Eigen Solvers, Optimization, Mesh Adaptation, Stochastic Methods, Adelus, Amesos2, Anasazi, Belos, Compadre, Galeri, Ifpack2, Intrepid2, Kokkos, Krino, MiniTensor, Muelu, PAMGEN, Panzer, Percept, Phalanx, Piro, PyTrilinos2, ROL, RTop, Rapid Optimization Library, SEACAS, STK, Sacado, Shards, ShyLU, Stokhos, Stratimikos, Teko, Tempus, Teuchos, Thyra, Tpetra, TrilinosCouplings, Xpetra, Zoltan, Zoltan2, Trilinos package descriptions, Trilinos package documentation, Trilinos Doxygen, Trilinos GitHub repository, Trilinos continuous integration (CI), Trilinos continuous deployment (CD), Trilinos package teams, Trilinos package leads, Trilinos modular framework, Trilinos interoperability, Trilinos scalability, Trilinos finite element analysis, Trilinos mesh adaptation, Trilinos stochastic methods, Trilinos optimization, Trilinos linear solvers, Trilinos nonlinear solvers, Trilinos eigen solvers, Trilinos preconditioners, Trilinos time integration, Trilinos transient analysis, Trilinos data transfer, Trilinos DAG-based field evaluation, Trilinos meshless discretization, Trilinos high-order finite element discretizations, Trilinos signed distance fields, Trilinos unstructured meshes, Trilinos parallel services, Trilinos load balancing, Trilinos combinatorial scientific computing, Trilinos smart pointers, Trilinos BLAS and LAPACK wrappers, Trilinos XML parsers, Trilinos vector operations, Trilinos parallel data redistribution, Trilinos abstract numerical algorithms, Trilinos linear algebra libraries, Trilinos unified solver interface, Trilinos automatic differentiation, Trilinos stochastic Galerkin methods, Trilinos uncertainty quantification, Trilinos PDE discretizations, Trilinos multigrid solvers, Trilinos domain decomposition methods, Trilinos distributed computing, Trilinos MPI support, Trilinos CUDA support, Trilinos Kokkos ecosystem, Trilinos performance portability, Trilinos massively parallel computations, Trilinos multi-physics computations, Trilinos interfaces between packages, Trilinos Couplings, Trilinos legacy packages, Trilinos experimental tools, Trilinos utilities
+keywords: Area Leads, Core Area, Solvers Area, Discretization and Analysis Area, Linear Systems, Performance Portability, Finite Element Analysis, Preconditioners, Eigen Solvers, Optimization, Mesh Adaptation, Stochastic Methods, Adelus, Amesos2, Anasazi, Belos, Compadre, Galeri, Ifpack2, Intrepid2, Kokkos, Krino, MiniTensor, MueLu, PAMGEN, Panzer, Percept, Phalanx, Piro, PyTrilinos2, ROL, RTop, Rapid Optimization Library, SEACAS, STK, Sacado, Shards, ShyLU, Stokhos, Stratimikos, Teko, Tempus, Teuchos, Thyra, Tpetra, TrilinosCouplings, Xpetra, Zoltan, Zoltan2, Trilinos package descriptions, Trilinos package documentation, Trilinos Doxygen, Trilinos GitHub repository, Trilinos continuous integration (CI), Trilinos continuous deployment (CD), Trilinos package teams, Trilinos package leads, Trilinos modular framework, Trilinos interoperability, Trilinos scalability, Trilinos finite element analysis, Trilinos mesh adaptation, Trilinos stochastic methods, Trilinos optimization, Trilinos linear solvers, Trilinos nonlinear solvers, Trilinos eigen solvers, Trilinos preconditioners, Trilinos time integration, Trilinos transient analysis, Trilinos data transfer, Trilinos DAG-based field evaluation, Trilinos meshless discretization, Trilinos high-order finite element discretizations, Trilinos signed distance fields, Trilinos unstructured meshes, Trilinos parallel services, Trilinos load balancing, Trilinos combinatorial scientific computing, Trilinos smart pointers, Trilinos BLAS and LAPACK wrappers, Trilinos XML parsers, Trilinos vector operations, Trilinos parallel data redistribution, Trilinos abstract numerical algorithms, Trilinos linear algebra libraries, Trilinos unified solver interface, Trilinos automatic differentiation, Trilinos stochastic Galerkin methods, Trilinos uncertainty quantification, Trilinos PDE discretizations, Trilinos multigrid solvers, Trilinos domain decomposition methods, Trilinos distributed computing, Trilinos MPI support, Trilinos CUDA support, Trilinos Kokkos ecosystem, Trilinos performance portability, Trilinos massively parallel computations, Trilinos multi-physics computations, Trilinos interfaces between packages, Trilinos Couplings, Trilinos legacy packages, Trilinos experimental tools, Trilinos utilities
 ---
 
 ## Trilinos Area Leads
@@ -20,7 +20,7 @@ The Trilinos packages are organized into three main areas: **Core**, **Solvers**
   <tr style="background-color: lightblue;">
     <th><strong>Package</strong></th>
     <th><strong>Description</strong></th>
-    <th><strong>Doxygen</strong></th>
+    <th><strong>Documentation</strong></th>
     <th><strong>GitHub</strong></th>
     <th><strong>Team and Lead</strong></th>
   </tr>
@@ -35,30 +35,37 @@ The Trilinos packages are organized into three main areas: **Core**, **Solvers**
   <tr>
     <td><a href="https://github.com/kokkos" title="Kokkos">Kokkos</a></td>
     <td>Performance portability library.</td>
-    <td>N/A</td>
+    <td><a href="https://kokkos.org/kokkos-core-wiki/">Kokkos documentation</a></td>
     <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/kokkos">Kokkos</a></td>
-    <td>N/A</td>
+    <td><a href="https://kokkos.org/community/team/">Kokkos team</a></td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/kokkos" title="Kokkos">Kokkos Kernels</a></td>
+    <td>Mathematical Kernels for Node-Local Computations</td>
+    <td><a href="https://kokkos.org/kokkos-kernels/docs/">Kokkos Kernels documentation</a></td>
+    <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/kokkos-kernels">Kokkos Kernels</a></td>
+    <td><a href="https://kokkos.org/community/team/">Kokkos team</a></td>
   </tr>
   <tr>
     <td><a href="pamgen.html" title="PAMGEN">PAMGEN</a></td>
     <td>Creates hexahedral or quadrilateral (in 2D) finite element meshes of simple shapes (cubes and cylinders) in parallel.</td>
-    <td>N/A</td>
+    <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/pamgen/doc/sand_report">PAMGEN documentation</a></td>
     <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/pamgen">PAMGEN</a></td>
     <td><a href="https://github.com/orgs/trilinos/teams/pamgen">@pamgen</a> and
         <a href="mailto:rppawlo@sandia.gov">Roger Pawlowski</a> (<a href="https://github.com/rppawlo">@rppawlo</a>)</td>
   </tr>
   <tr>
     <td><a href="pytrilinos2.html" title="PyTrilinos2">PyTrilinos2</a></td>
-    <td>Replacement for PyTrilinos.</td>
+    <td>Python interfaces to several Trilinos packages.</td>
     <td>N/A</td>
-    <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/pytrilinos2">PyTrilinos2</a></td>
+    <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/PyTrilinos2">PyTrilinos2</a></td>
     <td><a href="https://github.com/orgs/trilinos/teams/pytrilinos2">@pytrilinos2</a> and
         <a href="mailto:caglusa@sandia.gov">Christian Glusa</a> (<a href="https://github.com/cgcgcg">@cgcgcg</a>)</td>
   </tr>
   <tr>
     <td><a href="rtop.html" title="RTOp">RTOp</a></td>
     <td>Provides the basic mechanism for implementing vector operations in a flexible and efficient manner.</td>
-    <td>N/A</td>
+    <td><a href="docs/rtop/index.html">RTOp Doxygen</a></td>
     <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/rtop">RTOp</a></td>
     <td><a href="https://github.com/orgs/trilinos/teams/rtop">@rtop</a> and
         <a href="mailto:rabartl@sandia.gov">Roscoe A. Bartlett</a> (<a href="https://github.com/bartlettroscoe">@bartlettroscoe</a>)</td>
@@ -66,7 +73,7 @@ The Trilinos packages are organized into three main areas: **Core**, **Solvers**
   <tr>
     <td><a href="https://github.com/sandialabs/seacas" title="SEACAS">SEACAS</a></td>
     <td>A suite of preprocessing, postprocessing, translation, and utility applications supporting finite element analysis software using the Exodus database file format.</td>
-    <td>N/A</td>
+    <td><a href="https://sandialabs.github.io/seacas-docs/sphinx/html/index.html">SEACAS Documentation</a></td>
     <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/seacas">SEACAS</a></td>
     <td><a href="https://github.com/orgs/trilinos/teams/seacas">@seacas</a> and
         <a href="mailto:tookusa@sandia.gov">Tolu Okusanya</a> (<a href="https://github.com/tokusanya">@tokusanya</a>)</td>
@@ -98,7 +105,7 @@ The Trilinos packages are organized into three main areas: **Core**, **Solvers**
   <tr>
     <td><a href="https://sandialabs.github.io/Zoltan/" title="Zoltan">Zoltan</a></td>
     <td>A toolkit of parallel services for dynamic, unstructured, and/or adaptive simulations, providing load balancing and related services.</td>
-    <td>N/A</td>
+    <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/zoltan/doc">Zoltan documentation</a></td>
     <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/zoltan">Zoltan</a></td>
     <td><a href="https://github.com/orgs/trilinos/teams/zoltan">@zoltan</a> and
         <a href="mailto:egboman@sandia.gov">Erik Boman</a> (<a href="https://github.com/egboman">@egboman</a>)</td>
@@ -106,7 +113,7 @@ The Trilinos packages are organized into three main areas: **Core**, **Solvers**
   <tr>
     <td><a href="zoltan2.html" title="Zoltan2">Zoltan2</a></td>
     <td>A package for load balancing and combinatorial scientific computing, viewed as a successor to Zoltan and Isorropia.</td>
-    <td>N/A</td>
+    <td><a href="docs/zoltan2/index.html">Zoltan2 Doxygen</a></td>
     <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/zoltan2">Zoltan2</a></td>
     <td><a href="https://github.com/orgs/trilinos/teams/zoltan2">@zoltan2</a> and
         <a href="mailto:egboman@sandia.gov">Erik Boman</a> (<a href="https://github.com/egboman">@egboman</a>)</td>
@@ -121,7 +128,7 @@ The Trilinos packages are organized into three main areas: **Core**, **Solvers**
   <tr style="background-color: lightyellow;">
     <td><strong>Package</strong></td>
     <td><strong>Description</strong></td>
-    <td><strong>Doxygen</strong></td>
+    <td><strong>Documentation</strong></td>
     <td><strong>GitHub</strong></td>
     <td><strong>Team</strong></td>
     <td><strong>Team Lead</strong></td>
@@ -167,7 +174,7 @@ The Trilinos packages are organized into three main areas: **Core**, **Solvers**
     <td><a href="mailto:csiefer@sandia.gov">Chris Siefert</a> (<a href="https://github.com/csiefer2">@csiefer2</a>), <a href="mailto:jhu@sandia.gov">Jonathan Hu</a> (<a href="https://github.com/jhux2">@jhux2</a>)</td>
   </tr>
   <tr>
-    <td><a href="muelu.html" title="Muelu">Muelu</a></td>
+    <td><a href="muelu.html" title="MueLu">MueLu</a></td>
     <td>Designed to solve large sparse linear systems of equations arising from PDE discretizations, providing multigrid solvers and preconditioners.</td>
     <td><a href="docs/muelu/index.html">MueLu Doxygen</a></td>
     <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/muelu">MueLu</a></td>
@@ -177,7 +184,7 @@ The Trilinos packages are organized into three main areas: **Core**, **Solvers**
   <tr>
     <td><a href="shylu.html" title="ShyLU">ShyLU</a></td>
     <td>Package for solving sparse linear systems using domain decomposition methods, focusing on distributed memory and node-level solvers.</td>
-    <td>N/A</td>
+    <td><a href="docs/shylu/index.html">ShyLU Doxygen</a></td>
     <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/shylu">ShyLU</a></td>
     <td><a href="https://github.com/orgs/trilinos/teams/shylu">@shylu</a></td>
     <td><a href="mailto:iyamaza@sandia.gov">Ichi Yamazaki</a> (<a href="https://github.com/iyamazaki">@iyamazaki</a>)</td>
@@ -216,7 +223,7 @@ The Trilinos packages are organized into three main areas: **Core**, **Solvers**
   <tr style="background-color: lightgreen;">
     <td><strong>Package</strong></td>
     <td><strong>Description</strong></td>
-    <td><strong>Doxygen</strong></td>
+    <td><strong>Documentation</strong></td>
     <td><strong>GitHub</strong></td>
     <td><strong>Team</strong></td>
     <td><strong>Team Lead</strong></td>
@@ -224,7 +231,7 @@ The Trilinos packages are organized into three main areas: **Core**, **Solvers**
   <tr>
     <td><a href="compadre.html" title="Compadre">Compadre</a></td>
     <td>Toolkit for meshless discretizations enabling the solution of differential equations and data transfer.</td>
-    <td>N/A</td>
+    <td><a href="docs/compadre/index.html">Compadre Doxygen</a></td>
     <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/compadre">Compadre</a></td>
     <td><a href="https://github.com/orgs/trilinos/teams/compadre">@compadre</a></td>
     <td><a href="mailto:pakuber@sandia.gov">Paul Kuberry</a> (<a href="https://github.com/kuberry">@kuberry</a>)</td>
@@ -286,7 +293,7 @@ The Trilinos packages are organized into three main areas: **Core**, **Solvers**
     <td><a href="mailto:mperego@sandia.gov">Mauro Perego</a> (<a href="https://github.com/mperego">@mperego</a>)</td>
   </tr>
   <tr>
-    <td><a href="rol.html" title="Rapid Optimization Library (ROL)">ROL</a></td>
+    <td><a href="https://rol.sandia.gov/" title="Rapid Optimization Library (ROL)">ROL</a></td>
     <td>Next-generation package for large-scale optimization, solving optimal design, control, and inverse problems.</td>
     <td><a href="docs/rol/index.html">ROL Doxygen</a></td>
     <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/rol">ROL</a></td>
@@ -312,7 +319,7 @@ The Trilinos packages are organized into three main areas: **Core**, **Solvers**
   <tr>
     <td><a href="stk.html" title="STK">STK</a></td>
     <td>Supports massively parallel multi-physics computations on dynamically changing unstructured meshes.</td>
-    <td>N/A</td>
+    <td><a href="pages/packages/stk/STKManual_2024-07-12-final.pdf">STK Manual</a></td>
     <td><a href="https://github.com/trilinos/Trilinos/tree/master/packages/stk">STK</a></td>
     <td><a href="https://github.com/orgs/trilinos/teams/stk">@stk</a></td>
     <td><a href="mailto:STK-NGPTeam@sandia.gov">STK Team</a> (<a href="https://github.com/orgs/trilinos/teams/stk">@stk</a>)</td>

--- a/pages/packages/muelu/muelu.md
+++ b/pages/packages/muelu/muelu.md
@@ -30,7 +30,7 @@ MueLu is extensible and allows for the research and development of new multigrid
 *   **Easy-to-use interface:** MueLu has a user-friendly parameter input deck which covers most important use cases, with reasonable defaults provided for common problem types.
 *   **Modern object-oriented software architecture:** MueLu is written completely in C++ as a modular object-oriented multigrid framework, which provides flexibility to combine and reuse existing components to develop novel multigrid methods.
 *   **Extensibility:** Due to its flexible design, MueLu is an excellent toolkit for research on novel multigrid concepts. Experienced multigrid users have full access to the underlying framework through an advanced XML based interface. Expert users may use and extend the C++ API directly.
-*   **Integration with Trilinos:** As a package of Trilinos, Muelu is well integrated into the Trilinos environment and can use either of the two main solver stacks:
+*   **Integration with Trilinos:** As a package of Trilinos, MueLu is well integrated into the Trilinos environment and can use either of the two main solver stacks:
     *   Epetra (32-bit) sparse linear algebra: AztecOO (Krylov solvers), Ifpack (algebraic smoothers), Amesos (sparse direct solvers), Zoltan (load rebalancing)
     *   Tpetra sparse linear algebra: Belos (Krylov solvers), Ifpack2( algebraic solvers), Amesos2 (sparse direct solvers), Zoltan2 (load rebalancing).
 *   **Broad range of supported platforms:** MueLu runs on wide variety of architectures, from desktop workstations to parallel Linux clusters and supercomputers.


### PR DESCRIPTION
- Switch links in topnav from drop-down to simple links.
- Add "Packages" link to topnav. (I think it's a nice page to keep for users that know about the packages.)
- Switch "Doxygen" column to "Documentation" on packages-by-area page and add more links.